### PR TITLE
Adding archive directive to exclude tests, docs and design from the composer archive

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,13 @@
             "src"
         ]
     },
+    "archive": {
+        "exclude": [
+            "tests",
+            "docs",
+            "design"
+        ]
+    },
     "description": "This component allows you to set up and run your own WebDAV (RFC 2518) server, to enable online content editing for the users of your system through the WebDAV HTTP extension.",
     "homepage": "https://github.com/zetacomponents",
     "license": "Apache-2.0",


### PR DESCRIPTION
`composer archive` would fail because one of the test files containing
multibyte characters in the file name.

I ran into this issue while building a static composer/satis repository. Including the webdav component would cause satis to fail because apparently, there is an issue with phar files and multibyte characters.

I opened a satis issue (https://github.com/composer/satis/issues/70) and proposed a patch. However, it was suggested that I add the archive directive to the package.

The static repository will speed up the update process for our developers significantly. This may solve your issue #1. You might also consider building a satis repository for all zetacomponents just like zend framework did.
